### PR TITLE
Use bin-dir configuration via composer instead of having an alias on root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin
 composer.phar
 composer.lock
 vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - COMPOSER_ROOT_VERSION=dev-master php composer.phar --dev install
 
 script:
-  - ./atoum -d tests/units
+  - bin/atoum -d tests/units
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ whose Composer package can be installed with `dev` mode:
 
 ```
 php composer install --dev
-./atoum -d tests/units
+bin/atoum -d tests/units
 ```
 
 ## Complements

--- a/atoum
+++ b/atoum
@@ -1,1 +1,0 @@
-vendor/atoum/atoum/bin/atoum

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
 
     },
     "minimum-stability": "dev",
+    "config": {
+        "bin-dir": "bin"
+    },
     "autoload": {
         "psr-0": {
             "Sly": ["src/"]


### PR DESCRIPTION
Hi, 

Just a fix to use bin-dir configuration on composer, BTW, we can remove atoum alias on root dir.

If user does not want to launch tests, it'll not have a broken alias on root directory.
