### PR TITLE
Added ability to set custom data in the APNS adapter

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -135,7 +135,7 @@ class Apns extends BaseAdapter implements AdapterInterface
         $serviceMessage->setAlert($message->getText());
         $serviceMessage->setToken($device->getToken());
         $serviceMessage->setBadge($badge);
-        $serviceMessage->setCustom($message->getOption('custom'));
+        $serviceMessage->setCustom($message->getOption('custom', array()));
 
         if (null !== $sound) {
             $serviceMessage->setSound($sound);


### PR DESCRIPTION
Allows setting custom data (I think this was already implemented before but it seems like it's disappeared in v2).

``` php
$message = new Message('This is a basic example of push.');
$message->setOption('custom', $content);
```

I haven't added a special method for this, rather just using the `setOption` method. Is this OK or would you prefer a new method to be defined on a `Message`?
