### PR TITLE
Add support for getting the original response from APNS/GCM

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -67,12 +67,12 @@ class Apns extends BaseAdapter implements AdapterInterface
             $message = $this->getServiceMessageFromOrigin($device, $push->getMessage());
 
             try {
-                $response = $client->send($message);
+                $this->response = $client->send($message);
             } catch (ServiceRuntimeException $e) {
                 throw new PushException($e->getMessage());
             }
 
-            if (ServiceResponse::RESULT_OK === $response->getCode()) {
+            if (ServiceResponse::RESULT_OK === $this->response->getCode()) {
                 $pushedDevices->add($device);
             }
         }

--- a/src/Sly/NotificationPusher/Adapter/BaseAdapter.php
+++ b/src/Sly/NotificationPusher/Adapter/BaseAdapter.php
@@ -34,6 +34,11 @@ abstract class BaseAdapter extends BaseParameteredModel
     protected $environment;
 
     /**
+     * @var mixed
+     */
+    protected $response;
+
+    /**
      * Constructor.
      *
      * @param array $parameters Adapter specific parameters
@@ -57,6 +62,16 @@ abstract class BaseAdapter extends BaseParameteredModel
     public function __toString()
     {
         return ucfirst($this->getAdapterKey());
+    }
+
+    /**
+     * Return the original response.
+     * 
+     * @return mixed
+     */
+    public function getResponse()
+    {
+        return $this->response;
     }
 
     /**

--- a/src/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/src/Sly/NotificationPusher/Adapter/Gcm.php
@@ -52,12 +52,12 @@ class Gcm extends BaseAdapter implements AdapterInterface
             $message = $this->getServiceMessageFromOrigin($tokensRange, $push->getMessage());
 
             try {
-                $response = $client->send($message);
+                $this->response = $client->send($message);
             } catch (ServiceRuntimeException $e) {
                 throw new PushException($e->getMessage());
             }
 
-            if ((bool) $response->getSuccessCount()) {
+            if ((bool) $this->response->getSuccessCount()) {
                 foreach ($tokensRange as $token) {
                     $pushedDevices->add($push->getDevices()->get($token));
                 }


### PR DESCRIPTION
Implement support for returning the original remote response
from APNS and GCM. This is especially useful for parsing the
GCM HTTP response [1] so the user can update their registration
ids.

[1] http://developer.android.com/google/gcm/http.html#response
