### PR TITLE
Removed dependency on doctrine/common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,11 @@
         "symfony/console": ">=2.3",
         "symfony/process": ">=2.3",
         "zendframework/zendservice-apple-apns": "1.*",
-        "zendframework/zendservice-google-gcm": "1.*",
-        "doctrine/common": ">=2.3"
+        "zendframework/zendservice-google-gcm": "1.*"
     },
     "require-dev": {
-        "atoum/atoum": "master"
+        "atoum/atoum": "dev-master"
     },
-    "minimum-stability": "dev",
     "config": {
         "bin-dir": "bin"
     },


### PR DESCRIPTION
While integrating into symfony I needed doctrine/common dependency to go away. You don't use it and it conflicts with other composer configs
