### PR TITLE
Fixed token regex for GCM

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/src/Sly/NotificationPusher/Adapter/Gcm.php
@@ -44,7 +44,7 @@ class Gcm extends BaseAdapter
      */
     public function supports($token)
     {
-        return (bool) preg_match('/[0-9a-zA-Z\-\_]/i', $token);
+        return (bool) preg_match('/^[0-9a-zA-Z\-\_]+$/i', $token);
     }
 
     /**

--- a/tests/units/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/tests/units/Sly/NotificationPusher/Adapter/Gcm.php
@@ -51,6 +51,8 @@ class Gcm extends Units\Test
             ->and($object = new \Mock\Gcm())
             ->boolean($object->supports('*()*'))
                 ->isFalse()
+            ->boolean($object->supports('ABC*()*'))
+                ->isFalse()
             ->boolean($object->supports(self::GCM_TOKEN_EXAMPLE))
                 ->isTrue()
         ;


### PR DESCRIPTION
The token regex for the GCM adapter is a little off, since it's looking for only one of the specified characters in the string, not that the string only contains those characters.

I've tweaked it a little bit so that it no longer matches `AB*()*` which contains invalid characters. Also updated the tests to have an additional check for the invalid token.
