### PR TITLE
Setup the Gcm and Apns adapters to reuse their ServiceClient if one has been opened

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -36,6 +36,11 @@ use ZendService\Apple\Apns\Client\Feedback as ServiceFeedbackClient;
 class Apns extends BaseAdapter
 {
     /**
+     * @var ServiceClient
+     */
+    private $openedClient;
+
+    /**
      * {@inheritdoc}
      *
      * @throws \Sly\NotificationPusher\Exception\AdapterException
@@ -58,7 +63,7 @@ class Apns extends BaseAdapter
      */
     public function push(PushInterface $push)
     {
-        $client = $this->getOpenedClient(new ServiceClient());
+        $client = $this->getOpenedClient();
 
         $pushedDevices = new DeviceCollection();
 
@@ -103,19 +108,21 @@ class Apns extends BaseAdapter
     /**
      * Get opened client.
      *
-     * @param \ZendService\Apple\Apns\Client\AbstractClient $client Client
-     *
      * @return \ZendService\Apple\Apns\Client\AbstractClient
      */
-    public function getOpenedClient(ServiceAbstractClient $client)
+    public function getOpenedClient()
     {
-        $client->open(
-            $this->isProductionEnvironment() ? ServiceClient::PRODUCTION_URI : ServiceClient::SANDBOX_URI,
-            $this->getParameter('certificate'),
-            $this->getParameter('passPhrase')
-        );
+        if (!isset($this->openedClient)) {
+            $this->openedClient = new ServiceClient();
 
-        return $client;
+            $this->openedClient->open(
+                $this->isProductionEnvironment() ? ServiceClient::PRODUCTION_URI : ServiceClient::SANDBOX_URI,
+                $this->getParameter('certificate'),
+                $this->getParameter('passPhrase')
+            );
+        }
+
+        return $this->openedClient;
     }
 
     /**

--- a/src/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/src/Sly/NotificationPusher/Adapter/Gcm.php
@@ -40,6 +40,11 @@ class Gcm extends BaseAdapter
     private $httpClient;
 
     /**
+     * @var ServiceClient
+     */
+    private $openedClient;
+
+    /**
      * {@inheritdoc}
      */
     public function supports($token)
@@ -54,7 +59,7 @@ class Gcm extends BaseAdapter
      */
     public function push(PushInterface $push)
     {
-        $client        = $this->getOpenedClient(new ServiceClient());
+        $client        = $this->getOpenedClient();
         $pushedDevices = new DeviceCollection();
         $tokens        = array_chunk($push->getDevices()->getTokens(), 100);
 
@@ -80,22 +85,25 @@ class Gcm extends BaseAdapter
     /**
      * Get opened client.
      *
-     * @param \ZendService\Google\Gcm\Client $client Client
-     *
      * @return \ZendService\Google\Gcm\Client
      */
-    public function getOpenedClient(ServiceClient $client)
+    public function getOpenedClient()
     {
-        $client->setApiKey($this->getParameter('apiKey'));
+        if (!isset($this->openedClient)) {
+            $this->openedClient = new ServiceClient();
+            $this->openedClient->setApiKey($this->getParameter('apiKey'));
 
-        $newClient = new \Zend\Http\Client(null, array(
-            'adapter'       => 'Zend\Http\Client\Adapter\Socket',
-            'sslverifypeer' => false
-        ));
+            $newClient = new \Zend\Http\Client(
+                null, array(
+                    'adapter' => 'Zend\Http\Client\Adapter\Socket',
+                    'sslverifypeer' => false
+                )
+            );
 
-        $client->setHttpClient($newClient);
+            $this->openedClient->setHttpClient($newClient);
+        }
 
-        return $client;
+        return $this->openedClient;
     }
 
     /**


### PR DESCRIPTION
Fixes #22 

I don't know that this actually works, as I'm not in a position to test it.  In theory it's all makes sense: If the adapter has already opened a connection, then just reuse it!  We never seem to close these connections anywhere, but we make them fresh each time push is called, which is rather unnecessary.