### PR TITLE
Adds support for 'content-available' key from commit 9a1a1b3 in ZendServ...

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -134,7 +134,7 @@ class Apns extends BaseAdapter
         ;
 
         $sound = $message->getOption('sound', 'bingbong.aiff');
-        $contentAvailable = $message->getOption('content-avaibile');
+        $contentAvailable = $message->getOption('content-available');
 
         $alert = new ServiceAlert(
             $message->getText(),

--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -134,6 +134,7 @@ class Apns extends BaseAdapter
         ;
 
         $sound = $message->getOption('sound', 'bingbong.aiff');
+        $contentAvailable = $message->getOption('content-avaibile');
 
         $alert = new ServiceAlert(
             $message->getText(),
@@ -164,6 +165,10 @@ class Apns extends BaseAdapter
 
         if (null !== $sound) {
             $serviceMessage->setSound($sound);
+        }
+
+        if (null !== $contentAvailable) {
+            $serviceMessage->setContentAvailable($contentAvailable);
         }
 
         return $serviceMessage;


### PR DESCRIPTION
I updated the ZendService_Apple_Apns library to use the latest addition to APN - the 'content-available' key added in iOS7 (see [Table 3-1](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html))

This PR enables support for this.