### PR TITLE
Allow Optional GCM Parameters to be Defined

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/AdapterInterface.php
+++ b/src/Sly/NotificationPusher/Adapter/AdapterInterface.php
@@ -39,6 +39,13 @@ interface AdapterInterface
     public function supports($token);
 
     /**
+     * Get defined parameters.
+     *
+     * @return array
+     */
+    public function getDefinedParameters();
+
+    /**
      * Get default parameters.
      *
      * @return array

--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -180,6 +180,14 @@ class Apns extends BaseAdapter
     /**
      * {@inheritdoc}
      */
+    public function getDefinedParameters()
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getDefaultParameters()
     {
         return array('passPhrase' => null);

--- a/src/Sly/NotificationPusher/Adapter/BaseAdapter.php
+++ b/src/Sly/NotificationPusher/Adapter/BaseAdapter.php
@@ -46,6 +46,7 @@ abstract class BaseAdapter extends BaseParameteredModel implements AdapterInterf
     public function __construct(array $parameters = array())
     {
         $resolver = new OptionsResolver();
+        $resolver->setDefined($this->getDefinedParameters());
         $resolver->setDefaults($this->getDefaultParameters());
         $resolver->setRequired($this->getRequiredParameters());
 

--- a/src/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/src/Sly/NotificationPusher/Adapter/Gcm.php
@@ -126,6 +126,20 @@ class Gcm extends BaseAdapter
     /**
      * {@inheritdoc}
      */
+    public function getDefinedParameters()
+    {
+        return array(
+            'collapse_key',
+            'delay_while_idle',
+            'time_to_live',
+            'restricted_package_name',
+            'dry_run'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getDefaultParameters()
     {
         return array();

--- a/tests/units/Sly/NotificationPusher/Adapter/Apns.php
+++ b/tests/units/Sly/NotificationPusher/Adapter/Apns.php
@@ -62,6 +62,16 @@ class Apns extends Units\Test
         ;
     }
 
+    public function testDefinedParameters()
+    {
+        $this->if($this->mockGenerator()->orphanize('__construct'))
+            ->and($this->mockClass('\Sly\NotificationPusher\Adapter\Apns', '\Mock'))
+            ->and($object = new \Mock\Apns())
+            ->array($defaultParameters = $object->getDefinedParameters())
+                ->isEmpty()
+        ;
+    }
+
     public function testDefaultParameters()
     {
         $this->if($this->mockGenerator()->orphanize('__construct'))

--- a/tests/units/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/tests/units/Sly/NotificationPusher/Adapter/Gcm.php
@@ -58,6 +58,23 @@ class Gcm extends Units\Test
         ;
     }
 
+    public function testDefinedParameters()
+    {
+        $this->if($this->mockGenerator()->orphanize('__construct'))
+            ->and($this->mockClass('\Sly\NotificationPusher\Adapter\Gcm', '\Mock'))
+            ->and($object = new \Mock\Gcm())
+            ->array($definedParameters = $object->getDefinedParameters())
+            ->isNotEmpty()
+            ->containsValues(array(
+                'collapse_key',
+                'delay_while_idle',
+                'time_to_live',
+                'restricted_package_name',
+                'dry_run'
+            ))
+        ;
+    }
+
     public function testDefaultParameters()
     {
         $this->if($this->mockGenerator()->orphanize('__construct'))


### PR DESCRIPTION
The GCM adapter has five optional parameters that can be sent with the message (https://github.com/Ph3nol/NotificationPusher/blob/master/src/Sly/NotificationPusher/Adapter/Gcm.php#L117-L121):
- `collapse_key`
- `delay_while_idle`
- `time_to_live`
- `restricted_package_name`
- `dry_run`

Because these options aren't in the `getDefaultParamaters()` or `getRequiredParameters()` arrays they can't be set. A `Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException` with message `The option "dry_run" does not exist` is thrown if you try to use them.

These parameters are optional so adding them to the `getDefaultParamaters()` or `getRequiredParameters()` doesn't really make sense.

I have added a new `getDefinedParameters()` method that allows you to set optional parameters using the [setDefined()](http://symfony.com/doc/current/components/options_resolver.html#options-without-default-values) method.


