### PR TITLE
Modify composer.json to expose np as binary file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "atoum/atoum": "dev-master"
     },
     "config": {
-	"bin-dir": "bin"
+        "bin-dir": "bin"
     },
     "bin": ["np"],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     "require-dev": {
         "atoum/atoum": "dev-master"
     },
+    "config": {
+	"bin-dir": "bin"
+    },
     "bin": ["np"],
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,7 @@
     "require-dev": {
         "atoum/atoum": "dev-master"
     },
-    "config": {
-        "bin-dir": "bin"
-    },
+    "bin": ["np"],
     "autoload": {
         "psr-0": {
             "Sly": "src/"


### PR DESCRIPTION
Expose `np` as binary file, so that it can be easily acessible by `vendor/bin/np`.