### PR TITLE
GCM guideline changes

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/src/Sly/NotificationPusher/Adapter/Gcm.php
@@ -49,7 +49,7 @@ class Gcm extends BaseAdapter
      */
     public function supports($token)
     {
-        return (bool) preg_match('/^[0-9a-zA-Z\-\_]+$/i', $token);
+        return isset($token) && $token != '';
     }
 
     /**


### PR DESCRIPTION
Registration id could be up to 4k size and contain any characters.