### PR TITLE
Add safari push support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/options-resolver": "~2.3",
         "symfony/console": "~2.3",
         "symfony/process": "~2.3",
-        "zendframework/zendservice-apple-apns": "^1.1.0",
+        "zendframework/zendservice-apple-apns": "1.*",
         "zendframework/zendservice-google-gcm": "1.*",
         "doctrine/inflector": "~1.0"
     },

--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -165,9 +165,10 @@ class Apns extends BaseAdapter
             : 0
         ;
 
-        $sound = $message->getOption('sound', 'bingbong.aiff');
+        $sound = $message->getOption('sound');
         $contentAvailable = $message->getOption('content-available');
         $category = $message->getOption('category');
+        $urlArgs = $message->getOption('urlArgs');
 
         $alert = new ServiceAlert(
             $message->getText(),
@@ -220,6 +221,10 @@ class Apns extends BaseAdapter
 
         if (null !== $category) {
             $serviceMessage->setCategory($category);
+        }
+
+        if( null !== $urlArgs) {
+            $serviceMessage->setUrlArgs($urlArgs);
         }
 
         return $serviceMessage;

--- a/tests/units/Sly/NotificationPusher/Model/Push.php
+++ b/tests/units/Sly/NotificationPusher/Model/Push.php
@@ -62,6 +62,7 @@ class Push extends Units\Test
 
     public function testStatus()
     {
+        date_default_timezone_set('UTC');
         $this->if($this->mockClass('\Sly\NotificationPusher\Adapter\AdapterInterface', '\Mock'))
             ->and($adapter = new \Mock\AdapterInterface())
             ->and($devices = new BaseDeviceCollection(array(new BaseDevice('Token1'), new BaseDevice('Token2'), new BaseDevice('Token3'))))

--- a/tests/units/Sly/NotificationPusher/PushManager.php
+++ b/tests/units/Sly/NotificationPusher/PushManager.php
@@ -50,6 +50,7 @@ class PushManager extends Units\Test
 
     public function testPush()
     {
+        date_default_timezone_set('UTC');
         $this->if($this->mockGenerator()->orphanize('__construct'))
             ->and($this->mockClass('\Sly\NotificationPusher\Adapter\Apns', '\Mock'))
             ->and($apnsAdapter = new \Mock\Apns())


### PR DESCRIPTION
Adds support for Safari Push Notifications, specifically the required `url-args` property.  See https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html

Relies on the changes in https://github.com/zendframework/ZendService_Apple_Apns/pull/39 