### PR TITLE
Change notification badge to return false if there is no badge option…

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -162,7 +162,7 @@ class Apns extends BaseAdapter
     {
         $badge = ($message->hasOption('badge'))
             ? (int) ($message->getOption('badge') + $device->getParameter('badge', 0))
-            : 0
+            : false
         ;
 
         $sound = $message->getOption('sound', 'bingbong.aiff');
@@ -205,7 +205,7 @@ class Apns extends BaseAdapter
         $serviceMessage->setId(sha1($device->getToken().$message->getText()));
         $serviceMessage->setAlert($alert);
         $serviceMessage->setToken($device->getToken());
-        if (0 !== $badge) {
+        if (false !== $badge) {
             $serviceMessage->setBadge($badge);
         }
         $serviceMessage->setCustom($message->getOption('custom', array()));


### PR DESCRIPTION
There was change that prevented sending badge counter when its set to 0 since 0 is still a valid integer and should be allowed. This change allows sending badges to iOS devices even when its set to 0, however the use-case for adding the check is still valid since it checks for false now. 