### PR TITLE
added support for multiple response handler

### DIFF
--- a/doc/apns-adapter.md
+++ b/doc/apns-adapter.md
@@ -44,7 +44,17 @@ $message = new Message('This is a basic example of push.');
 // Finally, create and add the push to the manager, and push it!
 $push = new Push($apnsAdapter, $devices, $message);
 $pushManager->add($push);
-$pushManager->push();
+$collection = $pushManager->push();
+
+// Getting result for all APNS tokens
+foreach ($collection as $push) {
+    $adapter = $push->getAdapter();
+    $responseCollection = $adapter->getResponse();
+    foreach ($responseCollection as $token => $tokenStatus) {
+        // code should be 0 for successful send
+        var_dump($token . " - " . $tokenStatus->getCode()); 
+    }
+}
 ```
 
 ### Custom notification push example

--- a/doc/gcm-adapter.md
+++ b/doc/gcm-adapter.md
@@ -45,7 +45,23 @@ $message = new Message('This is an example.');
 // Finally, create and add the push to the manager, and push it!
 $push = new Push($gcmAdapter, $devices, $message);
 $pushManager->add($push);
-$pushManager->push(); // Returns a collection of notified devices
+$collection = $pushManager->push(); // Returns a collection of notified devices
+
+foreach ($collection as $push) {
+    $adapter = $push->getAdapter();
+    $response = $adapter->getResponse();
+    
+    foreach ($response as $pushChunk) {
+        // combine array of tokens and responses to preserve consistent of indexes
+        $tokens = $pushChunk->getMessage()->getRegistrationIds();
+        $responses = $pushChunk->getResults();
+        var_dump(array_combine($tokens, $responses));
+        
+        //there are also way to check only count of sent notifications
+        //var_dump($pushChunk->getSuccessCount());
+        //var_dump($pushChunk->getFailureCount());
+    }
+}
 ```
 
 ## Documentation index

--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -73,12 +73,12 @@ class Apns extends BaseAdapter
             $message = $this->getServiceMessageFromOrigin($device, $push->getMessage());
 
             try {
-                $this->response = $client->send($message);
+                $this->response[$device->getToken()] = $client->send($message);
             } catch (ServiceRuntimeException $e) {
                 throw new PushException($e->getMessage());
             }
 
-            if (ServiceResponse::RESULT_OK === $this->response->getCode()) {
+            if (ServiceResponse::RESULT_OK === $this->response[$device->getToken()]->getCode()) {
                 $pushedDevices->add($device);
             }
         }

--- a/src/Sly/NotificationPusher/Adapter/BaseAdapter.php
+++ b/src/Sly/NotificationPusher/Adapter/BaseAdapter.php
@@ -34,7 +34,7 @@ abstract class BaseAdapter extends BaseParameteredModel implements AdapterInterf
     protected $environment;
 
     /**
-     * @var mixed
+     * @var array
      */
     protected $response;
 
@@ -66,9 +66,9 @@ abstract class BaseAdapter extends BaseParameteredModel implements AdapterInterf
     }
 
     /**
-     * Return the original response.
+     * Return the array (map) of devices to original response.
      *
-     * @return mixed
+     * @return array
      */
     public function getResponse()
     {

--- a/src/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/src/Sly/NotificationPusher/Adapter/Gcm.php
@@ -63,16 +63,16 @@ class Gcm extends BaseAdapter
         $pushedDevices = new DeviceCollection();
         $tokens        = array_chunk($push->getDevices()->getTokens(), 100);
 
-        foreach ($tokens as $tokensRange) {
+        foreach ($tokens as $index => $tokensRange) {
             $message = $this->getServiceMessageFromOrigin($tokensRange, $push->getMessage());
 
             try {
-                $this->response = $client->send($message);
+                $this->response[$index] = $client->send($message);
             } catch (ServiceRuntimeException $e) {
                 throw new PushException($e->getMessage());
             }
 
-            if ((bool) $this->response->getSuccessCount()) {
+            if ((bool) $this->response[$index]->getSuccessCount()) {
                 foreach ($tokensRange as $token) {
                     $pushedDevices->add($push->getDevices()->get($token));
                 }


### PR DESCRIPTION
Previously we can get only last response for PN:
- GSM (if we have more than 100 devices that should get PN, we will get only response for the last chunk of devices)
- APNS (we can get only response for the last device in collection)

This pull request only simply changes the response to array that will store all response statuses for devices, not only the last one.
Also, this is fixes #104 
