### PR TITLE
Add expire support to APN adapter that is supported by ZendService\Ap…

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -168,6 +168,7 @@ class Apns extends BaseAdapter
         $sound = $message->getOption('sound', 'bingbong.aiff');
         $contentAvailable = $message->getOption('content-available');
         $category = $message->getOption('category');
+        $expire = $message->getOption('expire');
 
         $alert = new ServiceAlert(
             $message->getText(),
@@ -220,6 +221,10 @@ class Apns extends BaseAdapter
 
         if (null !== $category) {
             $serviceMessage->setCategory($category);
+        }
+
+        if (null !== $expire) {
+            $serviceMessage->setExpire($expire);
         }
 
         return $serviceMessage;


### PR DESCRIPTION
Add support to the expire parameter to APN push message, this acts as TTL.
Now if a mobile is offline or not connected to internet, the push notification will not received, the expire parameter allow the developer to add time to live to this message until it is ignored by APN
