### PR TITLE
#155, When failed to push message, re-initiate (re-open) connection

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -87,8 +87,12 @@ class Apns extends BaseAdapter implements FeedbackAdapterInterface
 
                 if (ServiceResponse::RESULT_OK === $response->getCode()) {
                     $pushedDevices->add($device);
-                }
-
+                }else{
+					$this->getOpenedClient()->close();
+					unset($this->openedClient);
+					$this->getOpenedServiceClient();
+				}
+				
                 $this->response->addOriginalResponse($device, $response);
                 $this->response->addParsedResponse($device, $responseArr);
             } catch (\RuntimeException $e) {


### PR DESCRIPTION
A proposed fix for #155 (An Invalid APNS Token Breaks Active Connection)