### PR TITLE
Assign returned new opened client to the in-scope/in-use  variable

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -90,7 +90,8 @@ class Apns extends BaseAdapter implements FeedbackAdapterInterface
                 } else {
                     $this->openedClient->close();
                     unset($this->openedClient);
-                    $this->getOpenedServiceClient();
+                    // Assign returned new client to the in-scope/in-use $client variable
+                    $client = $this->getOpenedServiceClient();
                 }
 
                 $this->response->addOriginalResponse($device, $response);


### PR DESCRIPTION
Missed to assign new opened connection to the $client variable which being used in foreach for sending $message

related to #156 