### PR TITLE
Fix PSR-4 fix for Composer deprecation

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/ApnsAPI.php
+++ b/src/Sly/NotificationPusher/Adapter/ApnsAPI.php
@@ -6,7 +6,7 @@
  * Time: 17:03
  */
 
-namespace Sly\Sly\NotificationPusher\Adapter;
+namespace Sly\NotificationPusher\Adapter;
 
 
 use Sly\NotificationPusher\Adapter\BaseAdapter;


### PR DESCRIPTION
Composer:

Deprecation Notice: Class Sly\Sly\NotificationPusher\Adapter\ApnsAPI located in ./vendor/sly/notification-pusher/src/Sly/NotificationPusher/Adapter/ApnsAPI.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /vendor/composer/composer/src/Composer/Autoload/ClassMapGenerator.php:185

The namespace just needs to be updated.