### PR TITLE
Add support to pass priority argument to GCM

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/src/Sly/NotificationPusher/Adapter/Gcm.php
@@ -159,6 +159,7 @@ class Gcm extends BaseAdapter
         $serviceMessage->setData($data);
 
         $serviceMessage->setCollapseKey($this->getParameter('collapseKey'));
+        $serviceMessage->setPriority($this->getParameter('priority', 'normal'));
         $serviceMessage->setRestrictedPackageName($this->getParameter('restrictedPackageName'));
         $serviceMessage->setDelayWhileIdle($this->getParameter('delayWhileIdle', false));
         $serviceMessage->setTimeToLive($this->getParameter('ttl', 600));

--- a/src/Sly/NotificationPusher/Adapter/Gcm.php
+++ b/src/Sly/NotificationPusher/Adapter/Gcm.php
@@ -175,6 +175,7 @@ class Gcm extends BaseAdapter
     {
         return [
             'collapseKey',
+            'priority',
             'delayWhileIdle',
             'ttl',
             'restrictedPackageName',


### PR DESCRIPTION
Currently, the default `normal` priority is being used for all GCM push notifications. This PR aims to allow that to be changed optionally

https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message