### PR TITLE
Remove check on token length as this can vary

### DIFF
--- a/src/Sly/NotificationPusher/Adapter/Apns.php
+++ b/src/Sly/NotificationPusher/Adapter/Apns.php
@@ -267,7 +267,7 @@ class Apns extends BaseAdapter implements FeedbackAdapterInterface
      */
     public function supports($token)
     {
-        return (ctype_xdigit($token) && 64 == strlen($token));
+        return ctype_xdigit($token);
     }
 
     /**


### PR DESCRIPTION
As per issue: https://github.com/Ph3nol/NotificationPusher/issues/185

The length can vary and Apple advises against hardcoded lengths: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW14