### PR TITLE
Update facade doc to prevent confusion

### DIFF
--- a/doc/facades.md
+++ b/doc/facades.md
@@ -22,7 +22,7 @@ $response->getPushCollection();
 $android_api_key = 'key';
 
 //get tokens list from your service
-$tokensA = ['token1', 'token2'];
+$tokensA = ['token1', 'token2', 'token3'];
 
 //get messages
 $messages = [
@@ -61,7 +61,7 @@ $certificatePath = 'cert.pem';
 $passPhrase      = '';
 
 //get tokens list
-$tokensA = ['token1', 'token2'];
+$tokensA = ['token1', 'token2', 'token3'];
 
 //get messages
 $messages = [

--- a/src/Sly/NotificationPusher/ApnsPushService.php
+++ b/src/Sly/NotificationPusher/ApnsPushService.php
@@ -52,8 +52,8 @@ class ApnsPushService extends AbstractPushService
     }
 
     /**
-     * @param array $tokens
-     * @param array $notifications
+     * @param array $tokens List of targets
+     * @param array $notifications Message(s) to send to each token
      * @param array $params
      * @return ResponseInterface
      */

--- a/src/Sly/NotificationPusher/GcmPushService.php
+++ b/src/Sly/NotificationPusher/GcmPushService.php
@@ -46,8 +46,8 @@ class GcmPushService extends AbstractPushService
      *      message
      *      device
      *
-     * @param array $tokens
-     * @param array $notifications
+     * @param array $tokens List of targets
+     * @param array $notifications Message(s) to send to each token
      * @param array $params
      * @return ResponseInterface
      */


### PR DESCRIPTION
resolves #186 

Very subtle change. 
The old one with the same length for $tokensA and $messages made me think that the list must always have equal length.
So once the code was live I did push the same message 100x times to each user ... (Only APNS, seems FCMS automatically ignores duplicate messages)